### PR TITLE
libreultra changes to match kirby 64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,11 @@ $(BUILD_DIR)/src/libc/ll%.o: MIPSISET := -mips3 -o32
 $(BUILD_DIR)/src/libc/ll.o: OPT_FLAGS := -O1
 $(BUILD_DIR)/src/libc/ll%.o: OPT_FLAGS := -O1
 $(BUILD_DIR)/src/os/exceptasm.o: MIPSISET := -mips3 -o32
+# Changes for kirby 64
+$(BUILD_DIR)/src/io/contreaddata.o: OPT_FLAGS := -O2
+$(BUILD_DIR)/src/io/sirawdma.o: OPT_FLAGS := -O2 -O2
+$(BUILD_DIR)/src/io/pfsreadwritefile.o: OPT_FLAGS := -O2
+
 
 
 #ifeq ($(TARGET_N64),1)

--- a/src/io/aisetnextbuf.c
+++ b/src/io/aisetnextbuf.c
@@ -2,11 +2,9 @@
 #include <rcp.h>
 #include "../os/osint.h"
 
-extern u8 hdwrBugFlag;
-
 s32 osAiSetNextBuffer(void *bufPtr, u32 size)
 {
-	// static u8 hdwrBugFlag = 0;
+	static u8 hdwrBugFlag = 0;
 	char *bptr = bufPtr;
 	if (hdwrBugFlag != 0)
 		bptr -= 0x2000;

--- a/src/io/controller.c
+++ b/src/io/controller.c
@@ -5,10 +5,16 @@
 
 #define HALF_A_SECOND OS_USEC_TO_CYCLES(500000)
 
-u32 __osContinitialized = 0;
-OSPifRam __osContPifRam;
-u8 __osContLastCmd;
-u8 __osMaxControllers;
+// u32 __osContinitialized = 0;
+// OSPifRam __osContPifRam;
+// u8 __osContLastCmd;
+// u8 __osMaxControllers;
+
+extern u32 __osContinitialized;
+extern OSPifRam __osContPifRam;
+extern u8 __osContLastCmd;
+extern u8 __osMaxControllers;
+
 // OSTimer __osEepromTimer;
 // OSMesgQueue __osEepromTimerQ;
 // OSMesg __osEepromTimerMsg;

--- a/src/io/controller.c
+++ b/src/io/controller.c
@@ -5,12 +5,11 @@
 
 #define HALF_A_SECOND OS_USEC_TO_CYCLES(500000)
 
-// u32 __osContinitialized = 0;
 // OSPifRam __osContPifRam;
 // u8 __osContLastCmd;
 // u8 __osMaxControllers;
 
-extern u32 __osContinitialized;
+u32 __osContinitialized = 0;
 extern OSPifRam __osContPifRam;
 extern u8 __osContLastCmd;
 extern u8 __osMaxControllers;

--- a/src/io/controller.h
+++ b/src/io/controller.h
@@ -154,7 +154,7 @@ s32 __osCheckPackId(OSPfs *pfs, __OSPackId *temp);
 s32 __osGetId(OSPfs *pfs);
 s32 __osCheckId(OSPfs *pfs);
 s32 __osPfsRWInode(OSPfs *pfs, __OSInode *inode, u8 flag, u8 bank);
-s32 __osPfsSelectBank(OSPfs *pfs);
+s32 __osPfsSelectBank(OSPfs *pfs, u32 bank);
 s32 __osPfsDeclearPage(OSPfs *pfs, __OSInode *inode, int file_size_in_pages, int *first_page, u8 bank, int *decleared, int *last_page);
 s32 __osPfsReleasePages(OSPfs *pfs, __OSInode *inode, u8 start_page, u16 *sum, u8 bank, __OSInodeUnit *last_page, int flag);
 s32 __osBlockSum(OSPfs *pfs, u8 page_no, u16 *sum, u8 bank);
@@ -186,8 +186,7 @@ extern u8 __osMaxControllers;
 #define SET_ACTIVEBANK_TO_ZERO        \
     if (pfs->activebank != 0)         \
     {                                 \
-        pfs->activebank = 0;          \
-        ERRCK(__osPfsSelectBank(pfs)) \
+        ERRCK(__osPfsSelectBank(pfs, 0)) \
     }
 
 #define PFS_CHECK_ID                              \

--- a/src/io/pfsallocatefile.c
+++ b/src/io/pfsallocatefile.c
@@ -167,15 +167,13 @@ static s32 __osClearPage(OSPfs *pfs, int page_no, u8 *data, u8 bank)
     int i;
     s32 ret;
     ret = 0;
-    pfs->activebank = bank;
-    ERRCK(__osPfsSelectBank(pfs));
+    ERRCK(__osPfsSelectBank(pfs, bank));
     for (i = 0; i < PFS_ONE_PAGE; i++)
     {
         ret = __osContRamWrite(pfs->queue, pfs->channel, page_no * PFS_ONE_PAGE + i, data, FALSE);
         if (ret != 0)
             break;
     }
-    pfs->activebank = 0;
-    ret = __osPfsSelectBank(pfs);
+    ret = __osPfsSelectBank(pfs, 0);
     return ret;
 }

--- a/src/io/pfsdeletefile.c
+++ b/src/io/pfsdeletefile.c
@@ -111,20 +111,17 @@ s32 __osBlockSum(OSPfs *pfs, u8 page_no, u16 *sum, u8 bank)
     s32 ret;
     u8 data[32];
     ret = 0;
-    pfs->activebank = bank;
-    ERRCK(__osPfsSelectBank(pfs));
+    ERRCK(__osPfsSelectBank(pfs, bank));
     for (i = 0; i < PFS_ONE_PAGE; i++)
     {
         ret = __osContRamRead(pfs->queue, pfs->channel, page_no * PFS_ONE_PAGE + i, data);
         if (ret != 0)
         {
-            pfs->activebank = 0;
-            __osPfsSelectBank(pfs);
+            __osPfsSelectBank(pfs, 0);
             return ret;
         }
         *sum = *sum + __osSumcalc(data, sizeof(data));
     }
-    pfs->activebank = 0;
-    ret = __osPfsSelectBank(pfs);
+    ret = __osPfsSelectBank(pfs, 0);
     return ret;
 }

--- a/src/io/pfsinitpak.c
+++ b/src/io/pfsinitpak.c
@@ -16,8 +16,7 @@ s32 osPfsInitPak(OSMesgQueue *queue, OSPfs *pfs, int channel)
     pfs->queue = queue;
     pfs->channel = channel;
     pfs->status = 0;
-    pfs->activebank = 0;
-    ERRCK(__osPfsSelectBank(pfs));
+    ERRCK(__osPfsSelectBank(pfs, 0));
     ERRCK(__osContRamRead(pfs->queue, pfs->channel, 1, (u8*)temp));
     __osIdCheckSum((u16*)temp, &sum, &isum);
     id = (__OSPackId *)temp;

--- a/src/io/pfsreadwritefile.c
+++ b/src/io/pfsreadwritefile.c
@@ -77,8 +77,7 @@ s32 osPfsReadWriteFile(OSPfs *pfs, s32 file_no, u8 flag, int offset, int size_in
         }
         if (pfs->activebank != cur_page.inode_t.bank)
         {
-            pfs->activebank = cur_page.inode_t.bank;
-            ERRCK(__osPfsSelectBank(pfs));
+            ERRCK(__osPfsSelectBank(pfs, cur_page.inode_t.bank));
         }
         blockno = cur_page.inode_t.page * PFS_ONE_PAGE + cur_block;
         if (flag == OS_READ)
@@ -94,8 +93,10 @@ s32 osPfsReadWriteFile(OSPfs *pfs, s32 file_no, u8 flag, int offset, int size_in
     if (flag == PFS_WRITE && (dir.status & DIR_STATUS_OCCUPIED) == 0)
     {
         dir.status |= DIR_STATUS_OCCUPIED;
-        pfs->activebank = 0;
-        ERRCK(__osPfsSelectBank(pfs));
+        if (pfs->activebank)
+        {
+            ERRCK(__osPfsSelectBank(pfs, 0));
+        }
         ERRCK(__osContRamWrite(pfs->queue, pfs->channel, pfs->dir_table + file_no, (u8*)&dir, FALSE));
     }
     return 0;

--- a/src/io/siacs.c
+++ b/src/io/siacs.c
@@ -1,9 +1,12 @@
 #include <os_internal.h>
 
 #define SI_Q_BUF_LEN 1
+// static OSMesg siAccessBuf[SI_Q_BUF_LEN];
+// OSMesgQueue __osSiAccessQueue;
 u32 __osSiAccessQueueEnabled = 0;
-static OSMesg siAccessBuf[SI_Q_BUF_LEN];
-OSMesgQueue __osSiAccessQueue;
+extern OSMesg siAccessBuf[SI_Q_BUF_LEN];
+extern OSMesgQueue __osSiAccessQueue;
+
 void __osSiCreateAccessQueue(void)
 {
 	__osSiAccessQueueEnabled = 1;

--- a/src/io/sirawdma.c
+++ b/src/io/sirawdma.c
@@ -3,7 +3,8 @@
 
 s32 __osSiRawStartDma(s32 direction, void *dramAddr)
 {
-    if (__osSiDeviceBusy())
+    // Inlined __osSiDeviceBusy to match kirby 64
+    if (IO_READ(SI_STATUS_REG) & (SI_STATUS_DMA_BUSY | SI_STATUS_RD_BUSY))
         return -1;
 
     if (direction == OS_WRITE)

--- a/src/os/initialize.c
+++ b/src/os/initialize.c
@@ -16,7 +16,8 @@ OSTime osClockRate = OS_CLOCK_RATE;
 s32 osViClock = VI_NTSC_CLOCK;
 u32 __osShutdown = 0;
 u32 __OSGlobalIntMask = OS_IM_ALL;
-u32 __osFinalrom;
+// u32 __osFinalrom;
+extern u32 __osFinalrom;
 void osInitialize()
 {
    u32 pifdata;

--- a/src/os/thread.c
+++ b/src/os/thread.c
@@ -1,11 +1,11 @@
 #include <os_internal.h>
 #include "osint.h"
-// TODO: remove kirby 64's version of these
-// struct __osThreadTail __osThreadTail = {0, -1};
-// OSThread *__osRunQueue = (OSThread *)&__osThreadTail;
-// OSThread *__osActiveQueue = (OSThread *)&__osThreadTail;
-// OSThread *__osRunningThread = {0};
-// OSThread *__osFaultedThread = {0};
+
+struct __osThreadTail __osThreadTail = {0, -1};
+OSThread *__osRunQueue = (OSThread *)&__osThreadTail;
+OSThread *__osActiveQueue = (OSThread *)&__osThreadTail;
+OSThread *__osRunningThread = {0};
+OSThread *__osFaultedThread = {0};
 void __osDequeueThread(OSThread **queue, OSThread *t)
 {
    register OSThread *pred;


### PR DESCRIPTION
* Added an argument to __osPfsSelectBank
* Moved data back into thread.c, aisetnextbuf.c
* Extern'd data in siacs.c
* Inlined __osSiDeviceBusy in sirawdma.c
* Extend'd bss in initialize.c
* Set some compile flags for certain libreultra files